### PR TITLE
Add a popular PHP API Client

### DIFF
--- a/Using-the-API/API.md
+++ b/Using-the-API/API.md
@@ -55,6 +55,7 @@ ___
 - [For Java, Kotlin](https://github.com/sys1yagi/mastodon4j)
 - [For C#](https://github.com/pawotter/mastodon-api-cs)
 - [For Haskell](https://github.com/syucream/hastodon)
+- [For PHP](https://github.com/TheCodingCompany/MastodonOAuthPHP)
 
 ___
 


### PR DESCRIPTION
This should resolve issue #79. The issue itself lists 4 different API clients but since we're only listing one library per language (or at least per context, i.e. browser vs. serverside JavaScript) I figured we'd just list the most popular PHP library of the four recommended.

On that note, should we remove `libodonjs` from the documentation? It's not very popular compared to the libraries already listed and breaks the one-client-per-context thing we've been doing so far.